### PR TITLE
fix: update video ad selector to include specific ad element for TBS …

### DIFF
--- a/src/content/vods/ima_sdk.ts
+++ b/src/content/vods/ima_sdk.ts
@@ -9,7 +9,7 @@
 import { SkipMode, Vod } from "../vod";
 export class IMASdk extends Vod {
   protected static SELECTOR_VIDEO_VJS: string = 'video[id^="vjs_video_"][id$="_html5_api"]' as const;
-  protected static SELECTOR_VIDEO_AD: string = 'video[title="Advertisement"], video[src^="https://"]' as const;
+  protected static SELECTOR_VIDEO_AD: string = 'video[title="Advertisement"], video#adPlayer' as const; // `video#adPlayer` is a video ad element on TBS FREE
   protected static SELECTOR_IMA_SDK: string = 'script[src$="ima3.js"]' as const;
 
   static isAvailable(): boolean {


### PR DESCRIPTION
This pull request updates the `SELECTOR_VIDEO_AD` constant in the `IMASdk` class to improve the identification of video ad elements on TBS FREE.

Specific change:

* [`src/content/vods/ima_sdk.ts`](diffhunk://#diff-cbf5bbe78485391b3705a628ba6e4353362e22af362f3f71d11089892de329f6L12-R12): Modified the `SELECTOR_VIDEO_AD` constant to replace `video[src^="https://"]` with `video#adPlayer`, which better matches the video ad elements on TBS FREE.…FREE