### PR TITLE
Bump to 0.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ This extension can be installed from [Chrome Web Store](https://chromewebstore.g
 
 ## Change logs
 
+### [0.0.2](https://github.com/horihiro/SkipVideoAds-ChromeExtension/releases/tag/0.0.2)
+Bug Fix(es)
+  - Any `video` tags which has `src="https://..."` are recognized as video advertisements ([#1](https://github.com/horihiro/SkipVideoAds-ChromeExtension/issues/1))
+
 ### [0.0.1](https://github.com/horihiro/SkipVideoAds-ChromeExtension/releases/tag/0.0.1)
 The First release
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,8 +2,8 @@
   "manifest_version": 3,
   "name": "Skip Video Ads",
   "short_name": "Skip Video Ads",
-  "version": "0.0.1",
-  "version_name": "0.0.1-ajisai",
+  "version": "0.0.2",
+  "version_name": "0.0.2-botan",
   "description": "A Chrome extension that skips video ads on Video platforms.",
   "permissions": [
     "storage"

--- a/src/content/vods/ima_sdk.ts
+++ b/src/content/vods/ima_sdk.ts
@@ -9,7 +9,7 @@
 import { SkipMode, Vod } from "../vod";
 export class IMASdk extends Vod {
   protected static SELECTOR_VIDEO_VJS: string = 'video[id^="vjs_video_"][id$="_html5_api"]' as const;
-  protected static SELECTOR_VIDEO_AD: string = 'video[title="Advertisement"], video[src^="https://"]' as const;
+  protected static SELECTOR_VIDEO_AD: string = 'video[title="Advertisement"], video#adPlayer' as const; // `video#adPlayer` is a video ad element on TBS FREE
   protected static SELECTOR_IMA_SDK: string = 'script[src$="ima3.js"]' as const;
 
   static isAvailable(): boolean {


### PR DESCRIPTION
This pull request updates the Chrome extension "Skip Video Ads" to version 0.0.2, addressing a bug in video ad detection and updating related metadata. Below are the most important changes grouped by theme:

### Bug Fixes:
* Updated the `SELECTOR_VIDEO_AD` in `src/content/vods/ima_sdk.ts` to correctly identify video ads by replacing the condition for `video[src^="https://"]` with `video#adPlayer`, which is specific to TBS FREE video ads.

### Metadata Updates:
* Updated the version and version name in `manifest.json` to `0.0.2` and `0.0.2-botan`, respectively, to reflect the new release.
* Added a changelog entry in `README.md` for version 0.0.2, documenting the bug fix for incorrectly recognized video ads.