### PR TITLE
Bump to 0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ This extension can be installed from [Chrome Web Store](https://chromewebstore.g
 ## Change logs
 
 ### [0.1.0](https://github.com/horihiro/SkipVideoAds-ChromeExtension/releases/tag/0.1.0)
-  - New feature(s)
   - Improve feature(s)
+    - Handling a next button on YouTube
   - Bug Fix(es)
     - Fix an infinite loop on Amazon Prime Video
 

--- a/README.md
+++ b/README.md
@@ -77,10 +77,13 @@ This extension can be installed from [Chrome Web Store](https://chromewebstore.g
 ## Change logs
 
 ### [0.1.0](https://github.com/horihiro/SkipVideoAds-ChromeExtension/releases/tag/0.1.0)
+  - New feature(s)
+  - Improve feature(s)
+  - Bug Fix(es)
 
 ### [0.0.2](https://github.com/horihiro/SkipVideoAds-ChromeExtension/releases/tag/0.0.2)
-Bug Fix(es)
-  - Any `video` tags which has `src="https://..."` are recognized as video advertisements ([#1](https://github.com/horihiro/SkipVideoAds-ChromeExtension/issues/1))
+  - Bug Fix(es)
+    - Any `video` tags which has `src="https://..."` are recognized as video advertisements ([#1](https://github.com/horihiro/SkipVideoAds-ChromeExtension/issues/1))
 
 ### [0.0.1](https://github.com/horihiro/SkipVideoAds-ChromeExtension/releases/tag/0.0.1)
 The First release

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ This extension can be installed from [Chrome Web Store](https://chromewebstore.g
   - New feature(s)
   - Improve feature(s)
   - Bug Fix(es)
+    - Fix an infinite loop on Amazon Prime Video
 
 ### [0.0.2](https://github.com/horihiro/SkipVideoAds-ChromeExtension/releases/tag/0.0.2)
   - Bug Fix(es)

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ This extension can be installed from [Chrome Web Store](https://chromewebstore.g
 
 ## Change logs
 
+### [0.1.0](https://github.com/horihiro/SkipVideoAds-ChromeExtension/releases/tag/0.1.0)
+
 ### [0.0.2](https://github.com/horihiro/SkipVideoAds-ChromeExtension/releases/tag/0.0.2)
 Bug Fix(es)
   - Any `video` tags which has `src="https://..."` are recognized as video advertisements ([#1](https://github.com/horihiro/SkipVideoAds-ChromeExtension/issues/1))

--- a/manifest.json
+++ b/manifest.json
@@ -2,8 +2,8 @@
   "manifest_version": 3,
   "name": "Skip Video Ads",
   "short_name": "Skip Video Ads",
-  "version": "0.0.2",
-  "version_name": "0.0.2-botan",
+  "version": "0.1.0",
+  "version_name": "0.1.0-chitosezakura",
   "description": "A Chrome extension that skips video ads on Video platforms.",
   "permissions": [
     "storage"

--- a/manifest.json
+++ b/manifest.json
@@ -16,6 +16,18 @@
   },
   "content_scripts": [
     {
+      "run_at": "document_start",
+      "world": "MAIN",
+      "all_frames": true,
+      "matches": [
+        "https://*/*"
+      ],
+      "js": [
+        "dist/contentScript/injection.js"
+      ]
+    },
+    {
+      "run_at": "document_end",
       "all_frames": true,
       "matches": [
         "https://*/*"

--- a/package.json
+++ b/package.json
@@ -2,10 +2,12 @@
   "scripts": {
     "clean": "node -e \"require('fs-extra').removeSync('./dist')\"",
     "build:mkdir": "node -e \"const fs = require('fs-extra'); fs.ensureDirSync('./dist/contentScript');\"",
-    "build": "npm run clean && npm run build:mkdir && npm run build:content",
-    "build:dev": "npm run clean && npm run build:mkdir && npm run build:dev:content",
+    "build": "npm run clean && npm run build:mkdir && npm run build:content && npm run build:injection",
+    "build:dev": "npm run clean && npm run build:mkdir && npm run build:dev:content && npm run build:injection",
     "build:content": "esbuild ./src/content/main.ts --bundle --minify --outfile=./dist/contentScript/main.js ",
     "build:dev:content": "esbuild ./src/content/main.ts --bundle --sourcemap=inline --outfile=./dist/contentScript/main.js ",
+    "build:injection": "esbuild ./src/content/injection.ts --bundle --minify --outfile=./dist/contentScript/injection.js ",
+    "build:dev:injection": "esbuild ./src/content/injection.ts --bundle --sourcemap=inline --outfile=./dist/contentScript/injection.js ",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {

--- a/src/content/injection.ts
+++ b/src/content/injection.ts
@@ -1,0 +1,22 @@
+import { AmazonPrimeVideo } from './vods/amazon_prime_video';
+import { YouTube } from './vods/youtube';
+import { IMASdk } from './vods/ima_sdk';
+
+(() => {
+  const VOD_CLASSES = [
+    AmazonPrimeVideo,
+    YouTube,
+    IMASdk,
+  ];
+  const init = () => {
+    const vodClass = VOD_CLASSES.find((vodClass) => {
+      if (vodClass.isAvailable()) {
+        console.debug(`${vodClass.name} detected`);
+        return true;
+      }
+      return false;
+    });
+    vodClass && vodClass.injection();
+  }
+  init();
+})();

--- a/src/content/injection.ts
+++ b/src/content/injection.ts
@@ -1,12 +1,12 @@
-import { AmazonPrimeVideo } from './vods/amazon_prime_video';
+// import { AmazonPrimeVideo } from './vods/amazon_prime_video';
 import { YouTube } from './vods/youtube';
-import { IMASdk } from './vods/ima_sdk';
+// import { IMASdk } from './vods/ima_sdk';
 
 (() => {
   const VOD_CLASSES = [
-    AmazonPrimeVideo,
+    // AmazonPrimeVideo,
     YouTube,
-    IMASdk,
+    // IMASdk,
   ];
   const init = () => {
     const vodClass = VOD_CLASSES.find((vodClass) => {

--- a/src/content/main.ts
+++ b/src/content/main.ts
@@ -42,7 +42,6 @@ import { minimatch } from 'minimatch';
       const vodClass = VOD_CLASSES.find((vodClass) => {
         if (vodClass.isAvailable()) {
           console.debug(`${vodClass.name} detected`);
-          vod = new vodClass();
           return true;
         }
         return false;

--- a/src/content/vod.ts
+++ b/src/content/vod.ts
@@ -68,6 +68,10 @@ ${skipMode === SkipMode.auto ? `<path transform="matrix(0 0.016 -0.016 0 46 17)"
     console.error('Need to implement startWatching');
     throw new Error('Not implemented');
   }
+  static injection() {
+    console.error('Need to implement startWatching');
+    throw new Error('Not implemented');
+  }
   startWatching(skipMode: SkipMode = SkipMode.auto) {
     console.error('Need to implement startWatching');
     throw new Error('Not implemented');

--- a/src/content/vods/amazon_prime_video.ts
+++ b/src/content/vods/amazon_prime_video.ts
@@ -1,3 +1,4 @@
+import { sleepAsync } from '../../utils/timer';
 import { SkipMode, Vod } from '../vod';
 
 export class AmazonPrimeVideo extends Vod {
@@ -14,6 +15,7 @@ export class AmazonPrimeVideo extends Vod {
     const time = remainingTime.textContent.replace(/.*(\d{1,2}:\d{2}).*/g, '$1');
     if (!time || time === '0:00') return;
     const minAndSec = time.split(':').map((t) => parseInt(t));
+    if (minAndSec.length !== 2 || minAndSec.some(isNaN) || minAndSec[0] * 60 + minAndSec[1] < 1 + this.TIMEGAP) return;
     this.skipVideo(videoElm, minAndSec[0] * 60 + minAndSec[1] - 0.5);
   }
 
@@ -39,6 +41,7 @@ export class AmazonPrimeVideo extends Vod {
         !overlay.parentElement && videoElm.closest('.webPlayerSDKContainer, [id^="dv-web-player"]>*')?.appendChild(overlay);
 
         if (skipMode === SkipMode.auto) {
+          await sleepAsync(100);
           this.seekToEnd(videoElm);
         } else if (skipMode === SkipMode.manual) {
           const clickTarget = overlay;

--- a/src/content/vods/amazon_prime_video.ts
+++ b/src/content/vods/amazon_prime_video.ts
@@ -8,6 +8,10 @@ export class AmazonPrimeVideo extends Vod {
     return /amazon\.(com|co\.jp)\//.test(location.href);
   }
 
+  static injection(): boolean {
+    return true;
+  }
+
   seekToEnd(videoElm: HTMLMediaElement) {
     const remainingTime = document.querySelector(AmazonPrimeVideo.SELECTOR_COUNTDOWN);
     if (!remainingTime) return;

--- a/src/content/vods/ima_sdk.ts
+++ b/src/content/vods/ima_sdk.ts
@@ -17,6 +17,9 @@ export class IMASdk extends Vod {
         || !!document.querySelector(IMASdk.SELECTOR_VIDEO_AD)
         || !!document.querySelector(IMASdk.SELECTOR_VIDEO_VJS);
   }
+  static injection(): boolean {
+    return true;
+  }
 
   seekToEnd(videoElm: HTMLMediaElement) {
     if (!videoElm) return;

--- a/src/content/vods/youtube.ts
+++ b/src/content/vods/youtube.ts
@@ -7,6 +7,7 @@ export class YouTube extends Vod {
   }
 
   static injection(): boolean {
+    // To set IsTrusted to true
     const deepCopy = (src) => {
       let target = src;
       let dst = {};
@@ -15,7 +16,13 @@ export class YouTube extends Vod {
           dst = Object.assign(dst, Object.getOwnPropertyNames(target)
             .reduce((p, k) => {
               try {
-                if (typeof p[k] !== 'function' && !p[k]) p[k] = src[k];
+                p[k] = (typeof src[k] !== 'function') ? src[k] : function (...args) {
+                  const result = src[k].apply(src, args);
+                  if (result && typeof result === 'object') {
+                    return deepCopy(result);
+                  }
+                  return result;
+                }
               } catch { }
               return p;
             }, dst));
@@ -28,13 +35,14 @@ export class YouTube extends Vod {
     }
     Element.prototype["_addEventListener"] = Element.prototype.addEventListener;
     Element.prototype.addEventListener = function () {
-      let args = [...arguments]
-      let temp = args[1];
+      const args = [...arguments];
+      const temp = args[1];
       args[1] = function () {
-        let args2 = [...arguments];
-        args2[0] = deepCopy(args2[0])
-        args2[0].isTrusted = true;
-        args2[0].preventDefault = () => { return true; };
+        const args2 = [...arguments];
+        const clone = deepCopy(args2[0])
+        clone['isTrusted'] = true;
+        clone['preventDefault'] = function () {}; 
+        args2[0] = clone
         return temp(...args2);
       }
       return this._addEventListener(...args);
@@ -64,8 +72,13 @@ export class YouTube extends Vod {
           overlay.parentElement && overlay.remove();
           return;
         }
+        const skipButton = document.querySelector('.ytp-skip-ad-button__text') as HTMLElement
+        if (skipButton) {
+          console.debug('Skip button found');
+          skipButton.click();
+        }
         const video = (e.target as HTMLMediaElement);
-        if (isNaN(video.duration) || isNaN(video.currentTime) || video.currentTime <= 0 || video.duration <= 0) return;
+        if (isNaN(video.duration) || isNaN(video.currentTime) || video.currentTime <= 0 || video.duration <= 0) {return};
 
         overlay.style.height = videoElm.style.height;
         videoElm.parentElement?.appendChild(overlay);

--- a/src/utils/timer.ts
+++ b/src/utils/timer.ts
@@ -1,0 +1,3 @@
+export function sleepAsync(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
This pull request introduces version `0.1.0` of the "Skip Video Ads" Chrome extension, which includes updates to the versioning, documentation, and codebase. The most notable changes involve updating the version metadata, adding a new changelog entry for the release, and modifying the logic in the `src/content/main.ts` file.

### Versioning and Metadata Updates:
* [`manifest.json`](diffhunk://#diff-ffa5b716b5a57837f7929dfcca4b4dfdeb97210a7fd5a12d2f1978846d6f1743L5-R6): Updated the `version` to `0.1.0` and the `version_name` to `0.1.0-chitosezakura`.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R79-R85): Added a changelog entry for version `0.1.0`, listing new features, improvements, and bug fixes.

### Codebase Changes:
* [`src/content/main.ts`](diffhunk://#diff-e63bd80c4669965c18d2c9210df59221bd89ba02bf3f9d7d3759098ab6323eaeL45): Removed the instantiation of the `vodClass` object within the `VOD_CLASSES` detection logic.