### PR TITLE
Bump to 0.2.2

### DIFF
--- a/CHANGELOGS.md
+++ b/CHANGELOGS.md
@@ -1,4 +1,9 @@
 ## Change logs
+### [0.2.2](https://github.com/horihiro/SkipVideoAds-ChromeExtension/releases/tag/0.2.2)
+  - Bug Fix(es)
+    - Improve event listener handling for non-click events
+    - Adjust skip timing and add debug logging for remaining time
+
 
 ### [0.2.1](https://github.com/horihiro/SkipVideoAds-ChromeExtension/releases/tag/0.2.1)
   - Bug Fix(es)

--- a/manifest.json
+++ b/manifest.json
@@ -2,8 +2,8 @@
   "manifest_version": 3,
   "name": "Skip Video Ads",
   "short_name": "Skip Video Ads",
-  "version": "0.2.1",
-  "version_name": "0.2.1-ebine",
+  "version": "0.2.2",
+  "version_name": "0.2.2-fukujuso",
   "description": "A Chrome extension that skips video ads on Video platforms.",
   "permissions": [
     "storage"

--- a/src/content/vods/amazon_prime_video.ts
+++ b/src/content/vods/amazon_prime_video.ts
@@ -20,7 +20,7 @@ export class AmazonPrimeVideo extends Vod {
     if (!time || time === '0:00') return;
     const minAndSec = time.split(':').map((t) => parseInt(t));
     if (minAndSec.length !== 2 || minAndSec.some(isNaN) || minAndSec[0] * 60 + minAndSec[1] < 1 + this.TIMEGAP) return;
-    this.skipVideo(videoElm, minAndSec[0] * 60 + minAndSec[1] - 0.5);
+    this.skipVideo(videoElm, minAndSec[0] * 60 + minAndSec[1] - 1);
   }
 
   startWatching(skipMode: SkipMode = 'auto'): void {

--- a/src/content/vods/youtube.ts
+++ b/src/content/vods/youtube.ts
@@ -35,7 +35,7 @@ export class YouTube extends Vod {
     }
     Element.prototype["_addEventListener"] = Element.prototype.addEventListener;
     Element.prototype.addEventListener = function () {
-      if (arguments[0] && arguments[0].toString() !== 'click') return this._addEventListener(...arguments);
+      if (!arguments || !arguments[0] || arguments[0].toString() !== 'click') return this._addEventListener(...arguments);
 
       const args = [...arguments];
       const temp = args[1];


### PR DESCRIPTION
This pull request updates the extension to version 0.2.2, focusing on bug fixes and improvements to event listener handling and ad skip timing. It also introduces additional debug logging for better visibility into remaining ad time.

**Bug fixes and improvements:**

* Improved event listener handling to better support non-click events in the `YouTube` VOD class, making the logic more robust.
* Adjusted the skip timing for Amazon Prime Video by increasing the buffer before skipping, which should improve reliability.

**Versioning and documentation:**

* Updated the version to `0.2.2` and version name to `0.2.2-fukujuso` in `manifest.json`.
* Added a changelog entry for version 0.2.2, summarizing the bug fixes and improvements.